### PR TITLE
Fix Jest transformIgnorePatterns

### DIFF
--- a/template/{% if test %}jest.config.js{% endif %}
+++ b/template/{% if test %}jest.config.js{% endif %}
@@ -1,6 +1,16 @@
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
 
-const esModules = ['@jupyterlab/'].join('|');
+const esModules = [
+  '@codemirror',
+  '@jupyter/ydoc',
+  '@jupyterlab/',
+  'lib0',
+  'nanoid',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
+  'yjs'
+].join('|');
 
 const baseConfig = jestJupyterLab(__dirname);
 
@@ -14,8 +24,5 @@ module.exports = {
   ],
   coverageReporters: ['lcov', 'text'],
   testRegex: 'src/.*/.*.spec.ts[x]?$',
-  transformIgnorePatterns: [
-    ...baseConfig.transformIgnorePatterns,
-    `/node_modules/(?!${esModules}).+`
-  ]
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
 };


### PR DESCRIPTION
Actually multiple entries in `transformIgnorePatterns` does not achieve the wanted behavior as documented:

https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization

And seen in

https://github.com/jupyterlab/jupyter_collaboration/pull/144