### PR TITLE
Use indent compatible with hatch-nodejs-version

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -1,205 +1,213 @@
 {
-  "name": "{{ labextension_name }}",
-  "version": "0.1.0",
-  "description": "{{ project_short_description }}",
-  "keywords": [
-    "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension"
-  ],
-  "homepage": "{{ repository }}",
-  "bugs": {
-    "url": "{{ repository }}/issues"
-  },
-  "license": "BSD-3-Clause",
-  "author": {
-    "name": "{{ author_name }}",
-    "email": "{{ author_email }}"
-  },
-  "files": [
-    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"{% if has_settings %},
-    "schema/*.json"{% endif %}
-  ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",{% if kind != 'theme' %}
-  "style": "style/index.css",{% endif %}
-  "repository": {
-    "type": "git",
-    "url": "{{ repository }}.git"
-  },{% if test %}
-  "workspaces": [
-    "ui-tests"
-  ],{% endif %}
-  "scripts": {
-    "build": "jlpm build:lib && jlpm build:labextension:dev",
-    "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
-    "build:labextension": "jupyter labextension build .",
-    "build:labextension:dev": "jupyter labextension build --development True .",
-    "build:lib": "tsc --sourceMap",
-    "build:lib:prod": "tsc",
-    "clean": "jlpm clean:lib",
-    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-    "clean:labextension": "rimraf {{ python_name }}/labextension {{ python_name }}/_version.py",
-    "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
-    "eslint": "jlpm eslint:check --fix",
-    "eslint:check": "eslint . --cache --ext .ts,.tsx",
-    "install:extension": "jlpm build",
-    "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
-    "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
-    "prettier": "jlpm prettier:base --write --list-different",
-    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "prettier:check": "jlpm prettier:base --check",
-    "stylelint": "jlpm stylelint:check --fix",
-    "stylelint:check": "stylelint --cache \"style/**/*.css\"",{% if test %}
-    "test": "jest --coverage",{% endif %}
-    "watch": "run-p watch:src watch:labextension",
-    "watch:src": "tsc -w --sourceMap",
-    "watch:labextension": "jupyter labextension watch ."
-  },
-  "dependencies": {
-    {% if kind.lower() != 'mimerenderer' %}"@jupyterlab/application": "^4.0.0"{% if kind.lower() == 'theme' %},
-    "@jupyterlab/apputils": "^4.0.0"{% endif %}{% if has_settings %},
-    "@jupyterlab/settingregistry": "^4.0.0"{% endif %}{% if kind.lower() == 'server' %},
-    "@jupyterlab/coreutils": "^6.0.0",
-    "@jupyterlab/services": "^7.0.0"{% endif %}{% else %}"@jupyterlab/rendermime-interfaces": "^3.8.0",
-    "@lumino/widgets": "^2.1.0"{% endif %}
-  },
-  "devDependencies": {
-    "@jupyterlab/builder": "^4.0.0",{% if test %}
-    "@jupyterlab/testutils": "^4.0.0",
-    "@types/jest": "^29.2.0",{% endif %}
-    "@types/json-schema": "^7.0.11",
-    "@types/react": "^18.0.26",
-    "@typescript-eslint/eslint-plugin": "^5.55.0",
-    "@typescript-eslint/parser": "^5.55.0",
-    "css-loader": "^6.7.1",
-    "eslint": "^8.36.0",
-    "eslint-config-prettier": "^8.7.0",
-    "eslint-plugin-prettier": "^4.2.1",{% if test %}
-    "jest": "^29.2.0",{% endif %}{% if kind.lower() == 'server' %}
-    "mkdirp": "^1.0.3",{% endif %}
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.7",
-    "rimraf": "^4.4.1",
-    "source-map-loader": "^1.0.2",
-    "style-loader": "^3.3.1",
-    "stylelint": "^14.9.1",
-    "stylelint-config-prettier": "^9.0.4",
-    "stylelint-config-recommended": "^8.0.0",
-    "stylelint-config-standard": "^26.0.0",
-    "stylelint-prettier": "^2.0.0",
-    "typescript": "~5.0.2",
-    "yjs": "^13.5.0"
-  },
-  "sideEffects": [
-    "style/*.css"{% if kind.lower() != 'theme' %},
-    "style/index.js"
-  ],
-  "styleModule": "style/index.js",{% else %}
-  ],{% endif %}
-  "publishConfig": {
-    "access": "public"
-  },
-  "jupyterlab": { {%- if kind.lower() == 'server' %}
-    "discovery": {
-      "server": {
-        "managers": [
-          "pip"
-        ],
-        "base": {
-          "name": "{{ python_name }}"
-        }
-      }
-    },{% endif %}{% if kind.lower() == 'mimerenderer' %}
-    "mimeExtension": true,{% else %}
-    "extension": true,{% endif %}
-    "outputDir": "{{python_name}}/labextension"{% if has_settings %},
-    "schemaDir": "schema"{% endif %}{% if kind.lower() == 'theme' %},
-    "themePath": "style/index.css"{% endif %}
-  },
-  "eslintIgnore": [
-    "node_modules",
-    "dist",
-    "coverage",
-    "**/*.d.ts"{% if test %},
-    "tests",
-    "**/__tests__",
-    "ui-tests"{% endif %}
-  ],
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:prettier/recommended"
+    "name": "{{ labextension_name }}",
+    "version": "0.1.0",
+    "description": "{{ project_short_description }}",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "tsconfig.json",
-      "sourceType": "module"
+    "homepage": "{{ repository }}",
+    "bugs": {
+        "url": "{{ repository }}/issues"
     },
-    "plugins": [
-      "@typescript-eslint"
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "{{ author_name }}",
+        "email": "{{ author_email }}"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"{% if has_settings %},
+        "schema/*.json"{% endif %}
     ],
-    "rules": {
-      "@typescript-eslint/naming-convention": [
-        "error",
-        {
-          "selector": "interface",
-          "format": [
-            "PascalCase"
-          ],
-          "custom": {
-            "regex": "^I[A-Z]",
-            "match": true
-          }
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        {
-          "args": "none"
-        }
-      ],
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-namespace": "off",
-      "@typescript-eslint/no-use-before-define": "off",
-      "@typescript-eslint/quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-          "allowTemplateLiterals": false
-        }
-      ],
-      "curly": [
-        "error",
-        "all"
-      ],
-      "eqeqeq": "error",
-      "prefer-arrow-callback": "error"
-    }
-  },
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "none",
-    "arrowParens": "avoid",
-    "endOfLine": "auto"
-  },
-  "stylelint": {
-    "extends": [
-      "stylelint-config-recommended",
-      "stylelint-config-standard",
-      "stylelint-prettier/recommended"
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",{% if kind != 'theme' %}
+    "style": "style/index.css",{% endif %}
+    "repository": {
+        "type": "git",
+        "url": "{{ repository }}.git"
+    },{% if test %}
+    "workspaces": [
+        "ui-tests"
+    ],{% endif %}
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf {{ python_name }}/labextension {{ python_name }}/_version.py",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",{% if test %}
+        "test": "jest --coverage",{% endif %}
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w --sourceMap",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "dependencies": {
+        {% if kind.lower() != 'mimerenderer' %}"@jupyterlab/application": "^4.0.0"{% if kind.lower() == 'theme' %},
+        "@jupyterlab/apputils": "^4.0.0"{% endif %}{% if has_settings %},
+        "@jupyterlab/settingregistry": "^4.0.0"{% endif %}{% if kind.lower() == 'server' %},
+        "@jupyterlab/coreutils": "^6.0.0",
+        "@jupyterlab/services": "^7.0.0"{% endif %}{% else %}"@jupyterlab/rendermime-interfaces": "^3.8.0",
+        "@lumino/widgets": "^2.1.0"{% endif %}
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4.0.0",{% if test %}
+        "@jupyterlab/testutils": "^4.0.0",
+        "@types/jest": "^29.2.0",{% endif %}
+        "@types/json-schema": "^7.0.11",
+        "@types/react": "^18.0.26",
+        "@typescript-eslint/eslint-plugin": "^5.55.0",
+        "@typescript-eslint/parser": "^5.55.0",
+        "css-loader": "^6.7.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.7.0",
+        "eslint-plugin-prettier": "^4.2.1",{% if test %}
+        "jest": "^29.2.0",{% endif %}{% if kind.lower() == 'server' %}
+        "mkdirp": "^1.0.3",{% endif %}
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.8.7",
+        "rimraf": "^4.4.1",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^3.3.1",
+        "stylelint": "^14.9.1",
+        "stylelint-config-prettier": "^9.0.4",
+        "stylelint-config-recommended": "^8.0.0",
+        "stylelint-config-standard": "^26.0.0",
+        "stylelint-prettier": "^2.0.0",
+        "typescript": "~5.0.2",
+        "yjs": "^13.5.0"
+    },
+    "sideEffects": [
+        "style/*.css"{% if kind.lower() != 'theme' %},
+        "style/index.js"
     ],
-    "rules": {
-      "property-no-vendor-prefix": null,
-      "selector-no-vendor-prefix": null,
-      "value-no-vendor-prefix": null{% if kind.lower() == "theme" %},
-      "alpha-value-notation": null,
-      "color-function-notation": null{% endif %}
+    "styleModule": "style/index.js",{% else %}
+    ],{% endif %}
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": { {%- if kind.lower() == 'server' %}
+        "discovery": {
+        "server": {
+            "managers": [
+                "pip"
+            ],
+            "base": {
+                "name": "{{ python_name }}"
+            }
+        }
+        },{% endif %}{% if kind.lower() == 'mimerenderer' %}
+        "mimeExtension": true,{% else %}
+        "extension": true,{% endif %}
+        "outputDir": "{{python_name}}/labextension"{% if has_settings %},
+        "schemaDir": "schema"{% endif %}{% if kind.lower() == 'theme' %},
+        "themePath": "style/index.css"{% endif %}
+    },
+    "eslintIgnore": [
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts"{% if test %},
+        "tests",
+        "**/__tests__",
+        "ui-tests"{% endif %}
+    ],
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "rules": {
+            "property-no-vendor-prefix": null,
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null{% if kind.lower() == "theme" %},
+            "alpha-value-notation": null,
+            "color-function-notation": null{% endif %}
+        }
     }
-  }
 }


### PR DESCRIPTION
Fixes #22

hatch-nodejs-version when bumping the version is saving back the package.json file using 4-spaces indentation. This aligns the prettier rule with that.