### PR TITLE
Add project URLs to pyproject

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -35,6 +35,10 @@ test = [
     "pytest-jupyter[server]>=0.6.0"
 ]
 {% endif %}
+[project.urls]
+Source = "{{ repository }}"
+Issues = "{{ repository }}/issues"
+
 [tool.hatch.version]
 source = "nodejs"
 


### PR DESCRIPTION
Equivalent URLs are already added in `package.json` but not in the `pyptoject.toml` (which is useful to link back from PyPI to repo).