### PR TITLE
Remove trailing slash from Playwright docs link

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -132,7 +132,7 @@ jlpm test
 
 #### Integration tests
 
-This extension uses [Playwright](https://playwright.dev/docs/intro/) for the integration tests (aka user level tests).
+This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
 More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
 
 More information are provided within the [ui-tests](./ui-tests/README.md) README.


### PR DESCRIPTION
The URL `https://playwright.dev/docs/intro/` returns a 404 which causes the link check to fail ([example](https://github.com/chrispyles/otter-grader-labextension/actions/runs/5500915267/jobs/10024153615)), the correct URL is `https://playwright.dev/docs/intro`.

![Screenshot 2023-07-09 at 9 59 53 AM](https://github.com/jupyterlab/extension-template/assets/40970945/160704e6-751c-425d-b111-5690ca27dd1e)
