### PR TITLE
Bump stylelint to 15.10.1

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -85,10 +85,9 @@
         "rimraf": "^4.4.1",
         "source-map-loader": "^1.0.2",
         "style-loader": "^3.3.1",
-        "stylelint": "^14.9.1",
-        "stylelint-config-prettier": "^9.0.4",
-        "stylelint-config-recommended": "^8.0.0",
-        "stylelint-config-standard": "^26.0.0",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
         "stylelint-prettier": "^2.0.0",
         "typescript": "~5.0.2",
         "yjs": "^13.5.0"


### PR DESCRIPTION
This follows the rollback of dependabot PRs such as https://github.com/jupyterlab-contrib/jupyter-ui-toolkit/pull/58