### PR TITLE
Pin `copier` in the conda command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install "copier~=7.2" jinja2-time "pydantic<2.0.0"
 Or with `conda` / `mamba`:
 
 ```sh
-conda install -c conda-forge copier jinja2-time
+conda install -c conda-forge "copier>=7,<8" jinja2-time
 ```
 
 2. Create an extension directory and go to it.


### PR DESCRIPTION
Follow the pin of the `pip` command.

Otherwise installing the latest `copier` from conda forge gives the following error:

```
$ copier copy https://github.com/jupyterlab/extension-template .                                                                                                                                                                                                                        
PREFIX/lib/python3.11/site-packages/copier/template.py:146: OldTemplateWarning: This template was designed for Copier 7.1.0, but your version of Copier is 8.1.0. You could find some incompatibilities.

Template uses unsafe feature: jinja_extensions
```