### PR TITLE
Remove `pip install -e .` step from the check release workflow

### DIFF
--- a/template/.github/workflows/check-release.yml.jinja
+++ b/template/.github/workflows/check-release.yml.jinja
@@ -13,9 +13,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Install Dependencies
-        run: |
-          pip install -e .
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -72,6 +72,7 @@
         "@types/jest": "^29.2.0",{% endif %}
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "css-loader": "^6.7.1",


### PR DESCRIPTION
This step should not be necessary and might add side-effects. Also it does not exist during the actual release process.

Noticed in https://github.com/jupyterlab/jupyterlab-github/pull/145#discussion_r1281551730