### PR TITLE
Fix ui-tests

### DIFF
--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -117,6 +117,7 @@ jobs:
     - name: Install dependencies
       working-directory: ui-tests
       env:
+        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       run: jlpm install
 {% raw %}

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -27,10 +27,7 @@
     "repository": {
         "type": "git",
         "url": "{{ repository }}.git"
-    },{% if test %}
-    "workspaces": [
-        "ui-tests"
-    ],{% endif %}
+    },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",
         "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",


### PR DESCRIPTION
The current project structure includes *ui-tests* as a workspace of the project.
In the same time there is an empty `yarn.lock` file it the *ui-test* directory, meaning (for yarn) that it should be treated as a completely separated project.

This PR assumes that we should treat the *ui-tests* as a separated project, and remove it from the project workspaces. It also allows to modify its *yarn.lock* file during CI.

If we aim to treat the *ui-tests* as a workspace (instead of a separated project), we should probably fix the `check_release` test which fails with workspaces (e.g. https://github.com/QuantStack/jupyter-sql-cell/actions/runs/6198336848/job/16828578630)