### PR TITLE
Switch from hub to gh CLI

### DIFF
--- a/template/.github/workflows/{% if test %}update-integration-tests.yml{% endif %}
+++ b/template/.github/workflows/{% if test %}update-integration-tests.yml{% endif %}
@@ -10,20 +10,23 @@ permissions:
 
 jobs:
   update-snapshots:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'please update playwright snapshots') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots') }}
     runs-on: ubuntu-latest
 
     steps:
+      - name: React to the triggering comment
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure git to use https
-        run: git config --global hub.protocol https
-
       - name: Checkout the branch from the PR that triggered the job
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This switches from `hub` CLI to `gh` following https://github.com/actions/runner-images/issues/8362

It also adds the :+1: reaction to the comment triggering the job and
Change the magic sentence from _please update playwright snapshots_ to _please update snapshots_