### PR TITLE
Add Python 3.12 classifier

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [{% if kind.lower() == "server" %}
     "jupyter_server>=2.0.1,<3"{% endif %}


### PR DESCRIPTION
Python 3.12 final is out: https://www.python.org/downloads/release/python-3120/

And the extension should normally work with Python 3.12.