### PR TITLE
Capitalize variable name (github_token -> GITHUB_TOKEN)

### DIFF
--- a/template/.github/workflows/{% if has_binder %}binder-on-pr.yml{% endif %}
+++ b/template/.github/workflows/{% if has_binder %}binder-on-pr.yml{% endif %}
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/binder-link@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since names of secrets are case-insensitive, this PR is just for styling.

In all other places, the upper case `GITHUB_TOKEN` is used, so I think it would be less confusing if they were unified.