### PR TITLE
Add concurrency rules on major workflows

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   names:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -5,11 +5,11 @@ on:
     branches: main
   pull_request:
     branches: '*'
-
+{% raw %}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
+{% endraw %}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/check-release.yml.jinja
+++ b/template/.github/workflows/check-release.yml.jinja
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: ["*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_release:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/check-release.yml.jinja
+++ b/template/.github/workflows/check-release.yml.jinja
@@ -4,11 +4,11 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["*"]
-
+{% raw %}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
+{% endraw %}
 jobs:
   check_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will automatically prevent running obsolete jobs (without the need for a bot like on jupyterlab core repo).