### PR TITLE
Normalize `repository` URL trailing slash

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,6 +1,6 @@
 # {{ python_name }}
 
-[![Github Actions Status]({{ repository }}/workflows/Build/badge.svg)]({{ repository }}/actions/workflows/build.yml)
+[![Github Actions Status]({{ repository|trim('/') }}/workflows/Build/badge.svg)]({{ repository|trim('/') }}/actions/workflows/build.yml)
 {% if has_binder -%}
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ repository|replace("https://github.com/", "") }}/main?urlpath=lab)
 

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -9,7 +9,7 @@
     ],
     "homepage": "{{ repository }}",
     "bugs": {
-        "url": "{{ repository }}/issues"
+        "url": "{{ repository | trim('/') }}/issues"
     },
     "license": "BSD-3-Clause",
     "author": {% if author_email %}{
@@ -27,7 +27,7 @@
     "style": "style/index.css",{% endif %}
     "repository": {
         "type": "git",
-        "url": "{{ repository }}.git"
+        "url": "{{ repository | trim('/') }}.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Closes #74 

## Considerations

- I didn't add the `trim()` filter to the `homepage` field since the trailing slash is not problematic. Let me know if I should do it or not.

## Testing

```bash
 pipx run --pip-args=jinja2-time==0.2.0 copier==9.2.0 copy --trust --vcs-ref fix-repository-trailing-slash https://github.com/joaopalmeiro/extension-template test
```

- `Git remote repository URL`: https://github.com/jupyterlab/extension-template
- `Git remote repository URL`: https://github.com/jupyterlab/extension-template/