### PR TITLE
Set packageManager

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -56,6 +56,7 @@
         "watch:src": "tsc -w --sourceMap",
         "watch:labextension": "jupyter labextension watch ."
     },
+    "packageManager": "yarn@3.5.0",
     "dependencies": {
         {% if kind.lower() != 'mimerenderer' %}"@jupyterlab/application": "^4.0.0"{% if kind.lower() == 'theme' %},
         "@jupyterlab/apputils": "^4.0.0"{% endif %}{% if kind.lower() == 'server' %},


### PR DESCRIPTION
This is set to avoid issue with tools like dependabot that may run a different version of yarn resulting in a different yarn.lock version.

> I could improve this using [copier-templates-extensions](https://github.com/copier-org/copier-templates-extensions) to run `jlpm --version`. But that will add a dependency.