### PR TITLE
Revert "Set packageManager"

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -56,7 +56,6 @@
         "watch:src": "tsc -w --sourceMap",
         "watch:labextension": "jupyter labextension watch ."
     },
-    "packageManager": "yarn@3.5.0",
     "dependencies": {
         {% if kind.lower() != 'mimerenderer' %}"@jupyterlab/application": "^4.0.0"{% if kind.lower() == 'theme' %},
         "@jupyterlab/apputils": "^4.0.0"{% endif %}{% if kind.lower() == 'server' %},


### PR DESCRIPTION
Reverts jupyterlab/extension-template#79 to avoid the annoyance of `corepack`. The trick is still valid for maintainer wishing to reduce the friction with dependabot update PRs.