### PR TITLE
Include `"keywords"` in the hatch-nodejs-version metadata hook plugin configuration

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -40,7 +40,7 @@ test = [
 source = "nodejs"
 
 [tool.hatch.metadata.hooks.nodejs]
-fields = ["description", "authors", "urls"]
+fields = ["description", "authors", "urls", "keywords"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["{{ python_name }}/labextension"]


### PR DESCRIPTION
Closes #80 

With this change, given that the `keywords` field is dynamic (`pyproject.toml`), the `keywords` defined in the `package.json` file would be considered for the Python package metadata.