### PR TITLE
Change `npm-run-all` to `npm-run-all2`

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -79,7 +79,7 @@
         "eslint-plugin-prettier": "^5.0.0",{% if test %}
         "jest": "^29.2.0",{% endif %}{% if kind.lower() == 'server' %}
         "mkdirp": "^1.0.3",{% endif %}
-        "npm-run-all": "^4.1.5",
+        "npm-run-all2": "^7.0.1",
         "prettier": "^3.0.0",
         "rimraf": "^5.0.1",
         "source-map-loader": "^1.0.2",


### PR DESCRIPTION
Closes #76 

Hi! 👋 

I changed `npm-run-all` to `npm-run-all2` considering the [latest version](https://github.com/bcomnes/npm-run-all2/blob/v7.0.1/CHANGELOG.md) (which supports at least Node.js 18). What do you think? Thanks!