### PR TITLE
Add template for gitlab continuous integration

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -64,6 +64,14 @@ test:
   help: Do you want to set up tests for the extension?
   default: yes
 
+ci:
+  type: str
+  help: What Continuous Integration service do you want to use?
+  choices:
+    GitHub CI: github
+    GitLab CI: gitlab
+  default: github
+
 repository:
   type: str
   help: Git remote repository URL

--- a/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
+++ b/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
@@ -1,0 +1,52 @@
+image: python
+
+rules:
+  - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  - if: $CI_COMMIT_BRANCH == "main"
+  - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
+    when: never
+
+stages:
+  - build
+{% if test %}
+  - test
+{% endif %}
+
+build:
+  stage: build
+  before_script:
+    # install dependencies
+    - apt update
+    - apt install -y nodejs npm
+    - python -m pip install -U "jupyterlab>=4.0.0,<5"
+    # lint checks
+    - set -eux
+    - jlpm
+    - jlpm run lint:check
+  script:
+    - set -eux
+    - python -m pip install .[test]
+{% if kind.lower() == 'server' %}
+    - jupyter server extension list
+    - jupyter server extension list 2>&1 | grep -ie "{{ python_name }}.*OK"
+{% endif %}
+    - jupyter labextension list
+    - jupyter labextension list 2>&1 | grep -ie "{{ labextension_name }}.*OK"
+    # Install dependencies for browser check
+    - npx playwright install-deps
+    - python -m jupyterlab.browser_check --allow-root
+
+{% if test %}
+test:
+  stage: test
+  before_script:
+    # install dependencies
+    - apt update
+    - apt install -y nodejs npm
+  script:
+    - set -eux
+    - python -m pip install .[test]
+    - jlpm run test
+{% if kind.lower() == 'server' %}
+    - pytest -vv -r ap --cov {{ python_name }}
+{% endif %}{% endif %}

--- a/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
+++ b/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
@@ -35,6 +35,12 @@ build:
     # Install dependencies for browser check
     - npx playwright install-deps
     - python -m jupyterlab.browser_check --allow-root
+    # Package the extension
+    - pip install build
+    - python -m build
+  artifacts:
+    paths:
+      - dist
 
 {% if test %}
 test:


### PR DESCRIPTION
Dear maintainers,

this pull request adds a template file with a basic gitlab continuous integration configuration.
The generation of the template is submitted to the user answer about which CI service they would like to use.

The release step is not implemented as hosted and on premises gitlab instances may offer different mechanisms for the upload.

Thanks for your attention.