### PR TITLE
Allow owners/members/collaborators to update snapshots on PRs of outside contributors

### DIFF
--- a/template/.github/workflows/{% if test %}update-integration-tests.yml{% endif %}
+++ b/template/.github/workflows/{% if test %}update-integration-tests.yml{% endif %}
@@ -14,7 +14,10 @@ jobs:
       (
         github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'MEMBER'
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER'
       ) && github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- Picks up https://github.com/jupyterlab/jupyterlab/pull/16872
- https://github.com/jupyterlab/jupyter-ai/issues/1159 made me realise we have not updated it it in the template