### PR TITLE
Run `install-deps` prior to integration tests

### DIFF
--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -134,6 +134,7 @@ jobs:
 {% endraw %}
     - name: Install browser
       run: |
+        set -eux
         jlpm playwright install-deps
         jlpm playwright install chromium
       working-directory: ui-tests

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -133,7 +133,9 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 {% endraw %}
     - name: Install browser
-      run: jlpm playwright install chromium
+      run: |
+        jlpm playwright install-deps
+        jlpm playwright install chromium
       working-directory: ui-tests
 
     - name: Execute integration tests


### PR DESCRIPTION
Follow-up of an issue seen in JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/17337#issuecomment-2694808254

Installing the os deps may have an effect on fonts e.g. that may induce discrepancies between the snapshot generated by the update snapshot action and the integration tests without this change.