### PR TITLE
Align TypeScript version with JupyterLab latest, add resolution pin for `lib0`

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -89,8 +89,11 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "~5.8.0",
+        "typescript": "~5.5.4",
         "yjs": "^13.5.0"
+    },
+    "resolutions": {
+        "lib0": "0.2.111"
     },
     "sideEffects": [
         "style/*.css"{% if kind.lower() != 'theme' %},


### PR DESCRIPTION
For #126