### PR TITLE
Ignore `.venv` for prettier and ESLint

### DIFF
--- a/template/.prettierignore.jinja
+++ b/template/.prettierignore.jinja
@@ -5,3 +5,4 @@ node_modules
 !/package.json
 {{python_name}}
 eslint.config.mjs
+.venv

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -12,7 +12,8 @@ export default defineConfig([
       'dist',
       'coverage',
       '**/*.js',
-      '**/*.d.ts'{% if test %},
+      '**/*.d.ts',
+      '.venv'{% if test %},
       'tests',
       '**/__tests__',
       'ui-tests'{% endif %}


### PR DESCRIPTION
Since it's quite common when creating new Python environment.