### PR TITLE
Move the contributing instructions to a separate `CONTRIBUTING.md` file

### DIFF
--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -1,0 +1,102 @@
+# Contributing
+
+## Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the {{ python_name }} directory
+
+# Set up a virtual environment and install package in development mode
+python -m venv .venv
+source .venv/bin/activate
+pip install --editable ".{% if test and kind.lower() == 'frontend-and-server' %}[dev,test]{% endif %}"
+
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite{% if kind.lower() == 'frontend-and-server' %}
+# Server extension must be manually installed in develop mode
+jupyter server extension enable {{ python_name }}{% endif %}
+
+# Rebuild extension Typescript source after making changes
+# IMPORTANT: Unlike the steps above which are performed only once, do this step
+# every time you make a change.
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+## Development uninstall
+
+```bash{% if kind.lower() == 'frontend-and-server' %}
+# Server extension must be manually disabled in develop mode
+jupyter server extension disable {{ python_name }}{% endif %}
+pip uninstall {{ python_name }}
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `{{ labextension_name }}` within that folder.
+{%- if test %}
+
+## Testing the extension{% if kind.lower() == 'frontend-and-server' %}
+
+### Server tests
+
+This extension is using [Pytest](https://docs.pytest.org/) for Python code testing.
+
+Install test dependencies (needed only once):
+
+```sh
+pip install -e ".[test]"
+# Each time you install the Python package, you need to restore the front-end extension link
+jupyter labextension develop . --overwrite
+```
+
+To execute them, run:
+
+```sh
+pytest -vv -r ap --cov {{ python_name }}
+```{% endif %}
+
+#### Frontend tests
+
+This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
+
+To execute them, execute:
+
+```sh
+jlpm
+jlpm test
+```
+
+### Integration tests
+
+This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
+More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
+
+More information are provided within the [ui-tests](./ui-tests/README.md) README.
+{%- endif %}
+
+## Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -94,7 +94,7 @@ jlpm test
 This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
 More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
 
-More information are provided within the [ui-tests](./ui-tests/README.md) README.
+More information is provided within the [ui-tests](./ui-tests/README.md) README.
 {%- endif %}
 
 ## Packaging the extension

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -3,6 +3,8 @@
 ## Development install
 
 Note: You will need Node.js to build the extension package.
+You may install it from [nodejs.org](https://nodejs.org/en/download). We
+recommend using the latest LTS version of Node.js.
 
 The `jlpm` command is JupyterLab's pinned version of
 [yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -2,7 +2,7 @@
 
 ## Development install
 
-Note: You will need NodeJS to build the extension package.
+Note: You will need Node.js to build the extension package.
 
 The `jlpm` command is JupyterLab's pinned version of
 [yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -49,102 +49,7 @@ jupyter labextension list
 {% endif %}
 ## Contributing
 
-### Development install
-
-Note: You will need NodeJS to build the extension package.
-
-The `jlpm` command is JupyterLab's pinned version of
-[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
-`yarn` or `npm` in lieu of `jlpm` below.
-
-```bash
-# Clone the repo to your local environment
-# Change directory to the {{ python_name }} directory
-
-# Set up a virtual environment and install package in development mode
-python -m venv .venv
-source .venv/bin/activate
-pip install --editable ".{% if test and kind.lower() == 'frontend-and-server' %}[dev,test]{% endif %}"
-
-# Link your development version of the extension with JupyterLab
-jupyter labextension develop . --overwrite{% if kind.lower() == 'frontend-and-server' %}
-# Server extension must be manually installed in develop mode
-jupyter server extension enable {{ python_name }}{% endif %}
-
-# Rebuild extension Typescript source after making changes
-# IMPORTANT: Unlike the steps above which are performed only once, do this step
-# every time you make a change.
-jlpm build
-```
-
-You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
-
-```bash
-# Watch the source directory in one terminal, automatically rebuilding when needed
-jlpm watch
-# Run JupyterLab in another terminal
-jupyter lab
-```
-
-With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
-
-By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
-
-```bash
-jupyter lab build --minimize=False
-```
-
-### Development uninstall
-
-```bash{% if kind.lower() == 'frontend-and-server' %}
-# Server extension must be manually disabled in develop mode
-jupyter server extension disable {{ python_name }}{% endif %}
-pip uninstall {{ python_name }}
-```
-
-In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
-command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
-folder is located. Then you can remove the symlink named `{{ labextension_name }}` within that folder.
-{%- if test %}
-
-### Testing the extension{% if kind.lower() == 'frontend-and-server' %}
-
-#### Server tests
-
-This extension is using [Pytest](https://docs.pytest.org/) for Python code testing.
-
-Install test dependencies (needed only once):
-
-```sh
-pip install -e ".[test]"
-# Each time you install the Python package, you need to restore the front-end extension link
-jupyter labextension develop . --overwrite
-```
-
-To execute them, run:
-
-```sh
-pytest -vv -r ap --cov {{ python_name }}
-```{% endif %}
-
-#### Frontend tests
-
-This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
-
-To execute them, execute:
-
-```sh
-jlpm
-jlpm test
-```
-
-#### Integration tests
-
-This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
-More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
-
-More information are provided within the [ui-tests](./ui-tests/README.md) README.
-{%- endif %}
+If you would like to contribute to this extension, please refer to the [Contributing Guide](CONTRIBUTING.md).
 {%- if has_ai_rules %}
 
 ## AI Coding Assistant Support
@@ -194,7 +99,3 @@ You can edit `AGENTS.md` to add project-specific conventions or adjust guideline
 
 **Note**: `AGENTS.md` is living documentation. Update it when you change conventions, add dependencies, or discover new patterns. Include `AGENTS.md` updates in commits that modify workflows or coding standards.
 {%- endif %}
-
-### Packaging the extension
-
-See [RELEASE](RELEASE.md)


### PR DESCRIPTION
Hi! As GitHub announced in https://github.blog/changelog/2025-08-07-contributing-guidelines-now-visible-in-repository-tab-and-sidebar/, a `CONTRIBUTING.md` file, when added to a repository, will start showing up in a separate "Contributing" tab immediately after the file listings. This was primarily done to enhance the visibility of the contributing instructions, so I thought this would be useful for the template here as well! I also fixed a typo and a grammatical error (see the last two commits!).

You may see how the tabs look like in the JupyterLab repository below:
<img width="920" height="63" alt="image" src="https://github.com/user-attachments/assets/53d5abc8-f9e6-405d-9650-166528897e62" />
