### PR TITLE
Faster playwright setup on CI

### DIFF
--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -135,8 +135,7 @@ jobs:
     - name: Install browser
       run: |
         set -eux
-        jlpm playwright install-deps
-        jlpm playwright install chromium
+        jlpm playwright install chromium --only-shell
       working-directory: ui-tests
 
     - name: Execute integration tests

--- a/template/{% if test %}ui-tests{% endif %}/package.json.jinja
+++ b/template/{% if test %}ui-tests{% endif %}/package.json.jinja
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@jupyterlab/galata": "^5.0.5",
-    "@playwright/test": "^1.37.0"
+    "@playwright/test": "^1.60.0"
   }
 }


### PR DESCRIPTION
Inspired by https://github.com/jupyterlab/jupyterlab/issues/18566

From https://playwright.dev/docs/browsers#chromium-headless-shell:

> Playwright ships a regular Chromium build for headed operations and a separate [chromium headless shell](https://developer.chrome.com/blog/chrome-headless-shell) for headless mode.
>
> If you are only running tests in headless shell (i.e. the channel option is not specified), for example on CI, you can avoid downloading the full Chromium browser by passing --only-shell during installation.

May I ask reviewers to apply this change in a few extensions they maintain so that we can confirm that this is a net positive? I believe for out use case we don't lose anything by not installing the extra dependencies but there might exist an extension where they require these. I think it would be unlikely and majority would benefit from faster CI.