### PR TITLE
Migrate `eslint` to v9 and use `@jupyter/eslint-plugin`

### DIFF
--- a/template/.prettierignore.jinja
+++ b/template/.prettierignore.jinja
@@ -4,3 +4,4 @@ node_modules
 **/package.json
 !/package.json
 {{python_name}}
+eslint.config.mjs

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -16,7 +16,7 @@ export default defineConfig([
       'tests',
       '**/__tests__',
       'ui-tests'{% endif %}
-    ],
+    ]
   },
   js.configs.recommended,
   tseslint.configs.recommended,

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -8,14 +8,14 @@ import jupyterPlugin from '@jupyter/eslint-plugin';
 export default defineConfig([
   {
     ignores: [
-      "node_modules",
-      "dist",
-      "coverage",
-      "**/*.js",
-      "**/*.d.ts"{% if test %},
-      "tests",
-      "**/__tests__",
-      "ui-tests"{% endif %}
+      'node_modules',
+      'dist',
+      'coverage',
+      '**/*.js',
+      '**/*.d.ts'{% if test %},
+      'tests',
+      '**/__tests__',
+      'ui-tests'{% endif %}
     ],
   },
   js.configs.recommended,

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -9,23 +9,22 @@ export default defineConfig([
   {
     ignores: [
       'node_modules/**',
-      '**/build/**',
-      '**/lib/**',
-      '**/node_modules/**',
+      'build/**',
+      'lib/**',
       '**/static/**',
-      '**/typings/**',
       '**/schemas/**',
-      '**/themes/**',
       'coverage/**',
-      '**/*.map.js',
-      '**/*.bundle.js',
       '.idea/**',
       '.history/**',
       '.vscode/**',
       '.pixi/**',
       '.venv/**',
       'docs/**',
-      '**/*.js'
+      '**/*.js',
+      "**/*.d.ts"{% if test %},
+      "tests",
+      "**/__tests__",
+      "ui-tests"{% endif %}
     ]
   },
   js.configs.recommended,

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -1,0 +1,77 @@
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+import prettierRecommended from 'eslint-plugin-prettier/recommended';
+import globals from 'globals';
+import jupyterPlugin from '@jupyter/eslint-plugin';
+
+export default defineConfig([
+  {
+    ignores: [
+      'node_modules/**',
+      '**/build/**',
+      '**/lib/**',
+      '**/node_modules/**',
+      '**/static/**',
+      '**/typings/**',
+      '**/schemas/**',
+      '**/themes/**',
+      'coverage/**',
+      '**/*.map.js',
+      '**/*.bundle.js',
+      '.idea/**',
+      '.history/**',
+      '.vscode/**',
+      '.pixi/**',
+      '.venv/**',
+      'docs/**',
+      '**/*.js'
+    ]
+  },
+  js.configs.recommended,
+  tseslint.configs.recommended,
+  jupyterPlugin.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    plugins: {
+      jupyter: jupyterPlugin
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.es2015,
+        ...globals.node
+      },
+      parserOptions: {
+        project: 'tsconfig.json',
+        sourceType: 'module'
+      }
+    },
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          custom: {
+            regex: '^I[A-Z]',
+            match: true
+          }
+        }
+      ],
+      '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-namespace': 'off',
+      '@typescript-eslint/no-use-before-define': 'off',
+      '@typescript-eslint/quotes': [
+        'error',
+        'single',
+        { avoidEscape: true, allowTemplateLiterals: false }
+      ],
+      curly: ['error', 'all'],
+      eqeqeq: 'error',
+      'prefer-arrow-callback': 'error'
+    }
+  },
+  prettierRecommended
+]);

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -8,24 +8,15 @@ import jupyterPlugin from '@jupyter/eslint-plugin';
 export default defineConfig([
   {
     ignores: [
-      'node_modules/**',
-      'build/**',
-      'lib/**',
-      '**/static/**',
-      '**/schemas/**',
-      'coverage/**',
-      '.idea/**',
-      '.history/**',
-      '.vscode/**',
-      '.pixi/**',
-      '.venv/**',
-      'docs/**',
-      '**/*.js',
-      '**/*.d.ts'{% if test %},
-      'tests',
-      '**/__tests__',
-      'ui-tests'{% endif %}
-    ]
+      "node_modules",
+      "dist",
+      "coverage",
+      "**/*.js",
+      "**/*.d.ts"{% if test %},
+      "tests",
+      "**/__tests__",
+      "ui-tests"{% endif %}
+    ],
   },
   js.configs.recommended,
   tseslint.configs.recommended,

--- a/template/eslint.config.mjs.jinja
+++ b/template/eslint.config.mjs.jinja
@@ -21,10 +21,10 @@ export default defineConfig([
       '.venv/**',
       'docs/**',
       '**/*.js',
-      "**/*.d.ts"{% if test %},
-      "tests",
-      "**/__tests__",
-      "ui-tests"{% endif %}
+      '**/*.d.ts'{% if test %},
+      'tests',
+      '**/__tests__',
+      'ui-tests'{% endif %}
     ]
   },
   js.configs.recommended,

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -92,7 +92,6 @@
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
         "typescript": "~5.5.4",
-        "typescript-eslint": "^8.0.0",
         "yjs": "^13.5.0"
     },
     "resolutions": {

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -42,7 +42,7 @@
         "clean:labextension": "rimraf {{ python_name }}/labextension {{ python_name }}/_version.py",
         "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
         "eslint": "jlpm eslint:check --fix",
-        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "eslint:check": "eslint . --cache",
         "install:extension": "jlpm build",
         "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
         "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
@@ -71,12 +71,14 @@
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
-        "@typescript-eslint/parser": "^6.1.0",
+        "@eslint/js": "^9.0.0",
+        "@jupyter/eslint-plugin": "^0.0.3",
+        "typescript-eslint": "^8.0.0",
         "css-loader": "^6.7.1",
-        "eslint": "^8.36.0",
-        "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-prettier": "^5.0.0",{% if test %}
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "globals": "^15.0.0",{% if test %}
         "jest": "^29.2.0",{% endif %}{% if kind.lower() == 'frontend-and-server' %}
         "mkdirp": "^1.0.3",{% endif %}
         "npm-run-all2": "^7.0.1",
@@ -90,6 +92,7 @@
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
         "typescript": "~5.5.4",
+        "typescript-eslint": "^8.0.0",
         "yjs": "^13.5.0"
     },
     "resolutions": {
@@ -120,69 +123,6 @@
         "outputDir": "{{python_name}}/labextension"{% if has_settings %},
         "schemaDir": "schema"{% endif %}{% if kind.lower() == 'theme' %},
         "themePath": "style/index.css"{% endif %}
-    },
-    "eslintIgnore": [
-        "node_modules",
-        "dist",
-        "coverage",
-        "**/*.d.ts"{% if test %},
-        "tests",
-        "**/__tests__",
-        "ui-tests"{% endif %}
-    ],
-    "eslintConfig": {
-        "extends": [
-            "eslint:recommended",
-            "plugin:@typescript-eslint/eslint-recommended",
-            "plugin:@typescript-eslint/recommended",
-            "plugin:prettier/recommended"
-        ],
-        "parser": "@typescript-eslint/parser",
-        "parserOptions": {
-            "project": "tsconfig.json",
-            "sourceType": "module"
-        },
-        "plugins": [
-            "@typescript-eslint"
-        ],
-        "rules": {
-            "@typescript-eslint/naming-convention": [
-                "error",
-                {
-                    "selector": "interface",
-                    "format": [
-                        "PascalCase"
-                    ],
-                    "custom": {
-                        "regex": "^I[A-Z]",
-                        "match": true
-                    }
-                }
-            ],
-            "@typescript-eslint/no-unused-vars": [
-                "warn",
-                {
-                    "args": "none"
-                }
-            ],
-            "@typescript-eslint/no-explicit-any": "off",
-            "@typescript-eslint/no-namespace": "off",
-            "@typescript-eslint/no-use-before-define": "off",
-            "@typescript-eslint/quotes": [
-                "error",
-                "single",
-                {
-                    "avoidEscape": true,
-                    "allowTemplateLiterals": false
-                }
-            ],
-            "curly": [
-                "error",
-                "all"
-            ],
-            "eqeqeq": "error",
-            "prefer-arrow-callback": "error"
-        }
     },
     "prettier": {
         "singleQuote": true,

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -65,15 +65,14 @@
         "@lumino/widgets": "^2.1.0"{% endif %}
     },
     "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "@jupyter/eslint-plugin": "^0.0.5",
         "@jupyterlab/builder": "^4.0.0",{% if test %}
         "@jupyterlab/testutils": "^4.0.0",
         "@types/jest": "^29.2.0",{% endif %}
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",
-        "@eslint/js": "^9.0.0",
-        "@jupyter/eslint-plugin": "^0.0.5",
-        "typescript-eslint": "^8.0.0",
         "css-loader": "^6.7.1",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
@@ -92,6 +91,7 @@
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
         "typescript": "~5.5.4",
+        "typescript-eslint": "^8.0.0",
         "yjs": "^13.5.0"
     },
     "resolutions": {

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -72,7 +72,7 @@
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",
         "@eslint/js": "^9.0.0",
-        "@jupyter/eslint-plugin": "^0.0.3",
+        "@jupyter/eslint-plugin": "^0.0.5",
         "typescript-eslint": "^8.0.0",
         "css-loader": "^6.7.1",
         "eslint": "^9.0.0",


### PR DESCRIPTION
### Description
- [x] Migrate `eslint` to v9 and use new flat config format (`.eslint.config.mjs`)
- [x] Add `@jupyter/eslint-plugin` with recommeded config for extensions.