### PR TITLE
Update release doc (add trusted publishing details)

### DIFF
--- a/template/RELEASE.md.jinja
+++ b/template/RELEASE.md.jinja
@@ -62,6 +62,14 @@ The extension repository should already be compatible with the Jupyter Releaser.
 the GitHub repository and the package managers need to be properly set up. Please
 follow the instructions of the Jupyter Releaser [checklist](https://jupyter-releaser.readthedocs.io/en/latest/how_to_guides/convert_repo_from_repo.html).
 
+For the release workflows in this repository, make sure GitHub is configured with:
+
+- a `release` environment
+- an `APP_PRIVATE_KEY` secret
+- an `APP_ID` repository variable
+
+When using [npm trusted publishing](https://docs.npmjs.com/trusted-publishers), `NPM_TOKEN` is not required (and trusted publishing is recommended). Configure `NPM_TOKEN` only if you are publishing without trusted publishers.
+
 Here is a summary of the steps to cut a new release:
 
 - Go to the Actions panel


### PR DESCRIPTION
This cam up while working on https://github.com/jupyterlab/plugin-playground/pull/167#discussion_r3099566132

This PR updates the docs to clarify that `NPM_TOKEN` is only needed when not using npm trusted publishing.




