### PR TITLE
Add `yarn_linker` copier flag under advanced options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -590,9 +590,8 @@ jobs:
         run: |
           set -eux
           mkdir myextension
-          python -m copier copy -l -d kind=${KIND} -d author_name="My Name" -d labextension_name=myextension -d repository="https://github.com/test/lab-extension" --vcs-ref HEAD --UNSAFE . myextension
+          python -m copier copy -l -d kind=${KIND} -d use_pnpm=y -d author_name="My Name" -d labextension_name=myextension -d repository="https://github.com/test/lab-extension" --vcs-ref HEAD --UNSAFE . myextension
           pushd myextension
-          sed -i 's/^\(nodeLinker:\s\).*$/\1pnpm/' .yarnrc.yml
           python -m pip install "jupyterlab>=4.0.0,<5"
           YARN_ENABLE_IMMUTABLE_INSTALLS=false jlpm
           if [ ! -d node_modules/.store ] ; then echo 'nodes_module directory should contain a .store directory when using pnpm nodeLinker'; exit 1; fi;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -590,7 +590,7 @@ jobs:
         run: |
           set -eux
           mkdir myextension
-          python -m copier copy -l -d kind=${KIND} -d use_pnpm=y -d author_name="My Name" -d labextension_name=myextension -d repository="https://github.com/test/lab-extension" --vcs-ref HEAD --UNSAFE . myextension
+          python -m copier copy -l -d kind=${KIND} -d yarn_linker=pnpm -d author_name="My Name" -d labextension_name=myextension -d repository="https://github.com/test/lab-extension" --vcs-ref HEAD --UNSAFE . myextension
           pushd myextension
           python -m pip install "jupyterlab>=4.0.0,<5"
           YARN_ENABLE_IMMUTABLE_INSTALLS=false jlpm

--- a/copier.yml
+++ b/copier.yml
@@ -59,10 +59,19 @@ has_binder:
   help: Do you want to set up Binder example?
   default: no
 
-use_pnpm:
+advanced:
   type: bool
-  help: Do you want to use pnpm as the node linker?
+  help: Configure advanced options?
   default: no
+
+yarn_linker:
+  when: "{{ advanced }}"
+  type: str
+  help: Which yarn node linker do you want to use?
+  choices:
+    - node-modules
+    - pnpm
+  default: node-modules
 
 test:
   type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -59,6 +59,11 @@ has_binder:
   help: Do you want to set up Binder example?
   default: no
 
+use_pnpm:
+  type: bool
+  help: Do you want to use pnpm as the node linker?
+  default: no
+
 test:
   type: bool
   help: Do you want to set up tests for the extension?

--- a/template/.yarnrc.yml
+++ b/template/.yarnrc.yml
@@ -1,2 +1,0 @@
-nodeLinker: node-modules
-enableScripts: false

--- a/template/.yarnrc.yml.jinja
+++ b/template/.yarnrc.yml.jinja
@@ -1,2 +1,2 @@
-nodeLinker: {% if use_pnpm %}pnpm{% else %}node-modules{% endif %}
+nodeLinker: {% if yarn_linker == 'pnpm' %}pnpm{% else %}node-modules{% endif %}
 enableScripts: false

--- a/template/.yarnrc.yml.jinja
+++ b/template/.yarnrc.yml.jinja
@@ -1,0 +1,2 @@
+nodeLinker: {% if use_pnpm %}pnpm{% else %}node-modules{% endif %}
+enableScripts: false

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -72,8 +72,8 @@
         "@types/jest": "^29.2.0",{% endif %}
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
-        "@types/react-addons-linked-state-mixin": "^0.14.22",
-        "css-loader": "^6.7.1",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",{% if use_pnpm %}
+        "css-loader": "^6.7.1",{% endif %}
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -82,9 +82,9 @@
         "mkdirp": "^1.0.3",{% endif %}
         "npm-run-all2": "^7.0.1",
         "prettier": "^3.0.0",
-        "rimraf": "^5.0.1",
+        "rimraf": "^5.0.1",{% if use_pnpm %}
         "source-map-loader": "^1.0.2",
-        "style-loader": "^3.3.1",
+        "style-loader": "^3.3.1",{% endif %}
         "stylelint": "^15.10.1",
         "stylelint-config-recommended": "^13.0.0",
         "stylelint-config-standard": "^34.0.0",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -72,7 +72,7 @@
         "@types/jest": "^29.2.0",{% endif %}
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
-        "@types/react-addons-linked-state-mixin": "^0.14.22",{% if use_pnpm %}
+        "@types/react-addons-linked-state-mixin": "^0.14.22",{% if yarn_linker == 'pnpm' %}
         "css-loader": "^6.7.1",{% endif %}
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
@@ -82,7 +82,7 @@
         "mkdirp": "^1.0.3",{% endif %}
         "npm-run-all2": "^7.0.1",
         "prettier": "^3.0.0",
-        "rimraf": "^5.0.1",{% if use_pnpm %}
+        "rimraf": "^5.0.1",{% if yarn_linker == 'pnpm' %}
         "source-map-loader": "^1.0.2",
         "style-loader": "^3.3.1",{% endif %}
         "stylelint": "^15.10.1",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -95,7 +95,8 @@
         "yjs": "^13.5.0"
     },
     "resolutions": {
-        "lib0": "0.2.111"
+        "lib0": "0.2.111",
+        "webpack": "5.106.0"
     },
     "sideEffects": [
         "style/*.css"{% if kind.lower() != 'theme' %},


### PR DESCRIPTION
## Fixes #78 
### References https://github.com/jupyterlab/extension-cookiecutter-ts/pull/293#issuecomment-1711247773 https://github.com/jupyterlab/extension-template/pull/133#discussion_r3292334802

### Description
 Adds a `use_pnpm` flag (default: no) that, when enabled, sets `nodeLinker: pnpm` in `.yarnrc.yml` and includes the required devDependencies that aren't needed by default.
 More such `devDependencies` will be added after the merge of https://github.com/jupyterlab/extension-template/pull/133
