### PR TITLE
Restore `@jupyterlab/builder` as dev dependency

### DIFF
--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -67,7 +67,8 @@
     "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@jupyter/builder": "^1.0.0",
-        "@jupyter/eslint-plugin": "^0.0.5",{% if yarn_linker == 'pnpm' %}
+        "@jupyter/eslint-plugin": "^0.0.5",
+        "@jupyterlab/builder": "^4.0.0",{% if yarn_linker == 'pnpm' %}
         "@jupyterlab/core-meta": "^4.6.0-beta.0",{% endif %}{% if test %}
         "@jupyterlab/testutils": "^4.0.0",{% endif %}{% if yarn_linker == 'pnpm' %}
         "@module-federation/runtime-tools": "^2.0.0",{% endif %}{% if test %}


### PR DESCRIPTION
`@jupyterlab/builder` is not anymore in dev dependencies, probably after #133.

Maybe I missed something, but without this package the labextension can't be built.

```bash
$ jupyter labextension build
Building extension in /home/brichet/projects/test
/home/brichet/mambaforge/envs/test/lib/python3.14/site-packages/jupyterlab/debuglog.py:54: UserWarning: An error occurred.
  warnings.warn("An error occurred.")
/home/brichet/mambaforge/envs/test/lib/python3.14/site-packages/jupyterlab/debuglog.py:55: UserWarning: ValueError: Extensions require a devDependency on @jupyterlab/builder@^4.5.8
  warnings.warn(msg[-1].strip())
/home/brichet/mambaforge/envs/test/lib/python3.14/site-packages/jupyterlab/debuglog.py:56: UserWarning: See the log file for details: /tmp/jupyterlab-debug-emp9fbdg.log
  warnings.warn(f"See the log file for details: {log_path!s}")
```

cc. @Darshan808 