### PR TITLE
Update pyproject license spec to follow PEP639

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -5,7 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "{{ python_name }}"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -16,7 +16,6 @@ classifiers = [
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Mime Renderers",{% endif %}
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",{% if kind.lower() == "theme" %}
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Themes",{% endif %}
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The old table with file/text is deprecated, see [PEP639](https://peps.python.org/pep-0639/). Now uses "license-files" for files to include in dist, and "license" field is an SPDX identifier.

This should also make programmatic license identification much easier.
