### PR TITLE
Remove redundant `setup.py` from generated extensions

### DIFF
--- a/template/setup.py
+++ b/template/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
## Summary

- remove the redundant `setup.py` from generated extensions
- rely on the existing Hatchling build backend configured in `pyproject.toml`

## Why

Generated extensions already use a modern PEP 517 build through Hatchling. The one-line setuptools shim is no longer needed, so keeping it only adds a legacy packaging file to new projects.

Closes #111

## Impact

Newly generated extensions no longer contain `setup.py`; their packaging behavior remains unchanged.

## Validation

- generated a default extension with Copier 9.17.0 and confirmed `setup.py` is absent
- ran `python -m build`; both the sdist and wheel built successfully
